### PR TITLE
Add @posthog/plugin-globals (0.0.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     },
     "dependencies": {},
     "devDependencies": {
+        "@posthog/plugin-globals": "0.0.1",
         "@posthog/plugin-scaffold": "0.4.2",
         "@types/jest": "^26.0.19",
         "@typescript-eslint/eslint-plugin": "^4.12.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
         "noImplicitReturns": true,
         "noUnusedParameters": true,
         "noEmit": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "types": ["../@posthog/plugin-globals"]
     },
     "exclude": ["**.test.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -539,6 +539,11 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
+"@posthog/plugin-globals@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-globals/-/plugin-globals-0.0.1.tgz#dc247e6bf15fd466763a695df6254be05f8148cc"
+  integrity sha512-s2dyDQhs4ZZTudH1qiVx2ImMDZsfJt+zoamh9aFwk8gcRrASW/Z28fxVVkmg2k21pibbgbirB1gruXlZgKwSNg==
+
 "@posthog/plugin-scaffold@0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.4.2.tgz#170516bf9593ba86e351b33e94bf4b6a019ce6f7"


### PR DESCRIPTION
## Changes

- Trying out the `@posthog/plugin-globals` package. No matter what we'll do with `meta`, we still have globals and will probably want some things to remain globals. This adds support for them.
![image](https://user-images.githubusercontent.com/53387/112286889-16289300-8c8c-11eb-822a-062fff4fa61a.png)

- The `plugin-globals` project needs to be extended with other globals. Currently only `posthog` is there.

## Checklist

-   [ ] Tests for new code
