### PR TITLE
Add IP cache for user props

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ const plugin: Plugin = {
             throw new Error('This PostHog version does not have GeoIP capabilities! Upgrade to PostHog 1.24.0 or later')
         }
         if (event.ip) {
-            const lastIpSet = await storage.get(event.distinct_id, `${event.ip}|${event.timestamp}`)
+            const lastIpSet = await storage.get(event.distinct_id, null)
             if (typeof lastIpSet === 'string') {
                 const [ip, timestamp] = lastIpSet.split('|')
                 if (ip === event.ip) {
@@ -67,6 +67,7 @@ const plugin: Plugin = {
                 }
             }
         }
+        await storage.set(event.distinct_id, `${event.ip}|${event.timestamp}`)
         return event
     },
 }

--- a/index.ts
+++ b/index.ts
@@ -9,10 +9,15 @@ const plugin: Plugin = {
             const lastIpSet = await storage.get(event.distinct_id, null)
             if (typeof lastIpSet === 'string') {
                 const [ip, timestamp] = lastIpSet.split('|')
+
+                // same ip as is currently set on the person
                 if (ip === event.ip) {
                     return event
                 }
+
                 if (event.timestamp && timestamp) {
+                    // new ip but this event is late and another event that happened
+                    // after but was received earlier already updated the props
                     if (new Date(event.timestamp) < new Date(timestamp)) {
                         return event
                     }

--- a/index.ts
+++ b/index.ts
@@ -66,8 +66,8 @@ const plugin: Plugin = {
                     event.$set_once[`$initial_geoip_${key}`] = value
                 }
             }
+            await storage.set(event.distinct_id, `${event.ip}|${event.timestamp || ''}`)
         }
-        await storage.set(event.distinct_id, `${event.ip}|${event.timestamp}`)
         return event
     },
 }


### PR DESCRIPTION
## Changes

Currently the plugin sets about 15 props on every event. This stores the ip for a distinct id and the last time the props were set so we can only add the props when:

1. The IP is different (so the data from MaxMind will be different) **AND**
2. The timestamp of the incoming event is later than a stored timestamp (to account for events arriving out of order)


context: https://posthog.slack.com/archives/C01F6QWTVB5/p1623341578181400
## Checklist

-   [ ] Tests for new code
