### PR TITLE
Empty defaults for person props

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -1,4 +1,4 @@
-import { Reader } from '@maxmind/geoip2-node'
+import { City, Reader } from '@maxmind/geoip2-node'
 import { Plugin, PluginMeta } from '@posthog/plugin-scaffold'
 // @ts-ignore
 import { createPageview, resetMeta } from '@posthog/plugin-scaffold/test/utils'
@@ -8,11 +8,19 @@ import * as index from '.'
 
 const { processEvent } = index as Required<Plugin>
 
-async function resetMetaWithMmdb(file = 'GeoLite2-City-Test.mmdb'): Promise<PluginMeta> {
+const DEFAULT_MMDB_FILE_NAME = 'GeoLite2-City-Test.mmdb'
+
+async function resetMetaWithMmdb(
+    transformResult = (res: City) => res as Record<string, any>,
+    file = DEFAULT_MMDB_FILE_NAME
+): Promise<PluginMeta> {
     const mmdb = await Reader.open(join(__dirname, file))
     return resetMeta({
         geoip: {
-            locate: (ipAddress: string) => mmdb.city(ipAddress),
+            locate: (ipAddress: string) => {
+                const res = mmdb.city(ipAddress)
+                return transformResult(res)
+            },
         },
     }) as PluginMeta
 }
@@ -54,6 +62,45 @@ test('person is enriched with IP location', async () => {
     expect(event!.$set_once).toEqual(
         expect.objectContaining({
             $initial_geoip_city_name: 'Linköping',
+            $initial_geoip_country_name: 'Sweden',
+            $initial_geoip_country_code: 'SE',
+            $initial_geoip_continent_name: 'Europe',
+            $initial_geoip_continent_code: 'EU',
+            $initial_geoip_latitude: 58.4167,
+            $initial_geoip_longitude: 15.6167,
+            $initial_geoip_time_zone: 'Europe/Stockholm',
+            $initial_geoip_subdivision_1_code: 'E',
+            $initial_geoip_subdivision_1_name: 'Östergötland County',
+        })
+    )
+})
+
+test('person props default to null if no values present', async () => {
+    const removeCityNameFromLookupResult = (res: City) => {
+        const { city, ...remainingResult } = res
+        return remainingResult
+    }
+    const event = await processEvent(
+        { ...createPageview(), ip: '89.160.20.129' },
+        await resetMetaWithMmdb(removeCityNameFromLookupResult)
+    )
+    expect(event!.$set).toEqual(
+        expect.objectContaining({
+            $geoip_city_name: null, // default to null
+            $geoip_country_name: 'Sweden',
+            $geoip_country_code: 'SE',
+            $geoip_continent_name: 'Europe',
+            $geoip_continent_code: 'EU',
+            $geoip_latitude: 58.4167,
+            $geoip_longitude: 15.6167,
+            $geoip_time_zone: 'Europe/Stockholm',
+            $geoip_subdivision_1_code: 'E',
+            $geoip_subdivision_1_name: 'Östergötland County',
+        })
+    )
+    expect(event!.$set_once).toEqual(
+        expect.objectContaining({
+            $initial_geoip_city_name: null, // default to null
             $initial_geoip_country_name: 'Sweden',
             $initial_geoip_country_code: 'SE',
             $initial_geoip_continent_name: 'Europe',

--- a/index.ts
+++ b/index.ts
@@ -3,15 +3,15 @@ import { Plugin } from '@posthog/plugin-scaffold'
 const ONE_DAY = 60 * 60 * 24 // 24h in seconds
 
 const defaultLocationSetAndSetOnceProps = {
-    $geoip_city_name: '',
-    $geoip_country_name: '',
-    $geoip_country_code: '',
-    $geoip_continent_name: '',
-    $geoip_continent_code: '',
-    $geoip_postal_code: '',
-    $geoip_latitude: '',
-    $geoip_longitude: '',
-    $geoip_time_zone: '',
+    $geoip_city_name: null,
+    $geoip_country_name: null,
+    $geoip_country_code: null,
+    $geoip_continent_name: null,
+    $geoip_continent_code: null,
+    $geoip_postal_code: null,
+    $geoip_latitude: null,
+    $geoip_longitude: null,
+    $geoip_time_zone: null,
 }
 
 const plugin: Plugin = {
@@ -76,10 +76,10 @@ const plugin: Plugin = {
                 }
 
                 if (setPersonProps) {
-                    event.$set = { ...(event.$set ?? {}), ...defaultLocationSetAndSetOnceProps }
+                    event.$set = { ...defaultLocationSetAndSetOnceProps, ...(event.$set ?? {}) }
                     event.$set_once = {
-                        ...(event.$set_once ?? {}),
                         ...defaultLocationSetAndSetOnceProps,
+                        ...(event.$set_once ?? {}),
                     }
                 }
 

--- a/index.ts
+++ b/index.ts
@@ -76,9 +76,9 @@ const plugin: Plugin = {
                 }
 
                 if (setPersonProps) {
-                    event.$set = { ...(event.$set ? event.$set : {}), ...defaultLocationSetAndSetOnceProps }
+                    event.$set = { ...(event.$set ?? {}), ...defaultLocationSetAndSetOnceProps }
                     event.$set_once = {
-                        ...(event.$set_once ? event.$set_once : {}),
+                        ...(event.$set_once ?? {}),
                         ...defaultLocationSetAndSetOnceProps,
                     }
                 }

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@ import { Plugin } from '@posthog/plugin-scaffold'
 
 const ONE_DAY = 60 * 60 * 24 // 24h in seconds
 
-const defaultLocationSetAndSetOnceProps = {
+const defaultLocationSetProps = {
     $geoip_city_name: null,
     $geoip_country_name: null,
     $geoip_country_code: null,
@@ -12,6 +12,18 @@ const defaultLocationSetAndSetOnceProps = {
     $geoip_latitude: null,
     $geoip_longitude: null,
     $geoip_time_zone: null,
+}
+
+const defaultLocationSetOnceProps = {
+    $initial_geoip_city_name: null,
+    $initial_geoip_country_name: null,
+    $initial_geoip_country_code: null,
+    $initial_geoip_continent_name: null,
+    $initial_geoip_continent_code: null,
+    $initial_geoip_postal_code: null,
+    $initial_geoip_latitude: null,
+    $initial_geoip_longitude: null,
+    $initial_geoip_time_zone: null,
 }
 
 const plugin: Plugin = {
@@ -76,9 +88,9 @@ const plugin: Plugin = {
                 }
 
                 if (setPersonProps) {
-                    event.$set = { ...defaultLocationSetAndSetOnceProps, ...(event.$set ?? {}) }
+                    event.$set = { ...defaultLocationSetProps, ...(event.$set ?? {}) }
                     event.$set_once = {
-                        ...defaultLocationSetAndSetOnceProps,
+                        ...defaultLocationSetOnceProps,
                         ...(event.$set_once ?? {}),
                     }
                 }


### PR DESCRIPTION
## Changes

It makes sense to skip certain props altogether in the general event properties, but it gets problematic with person properties. If one value doesn't get set, you run into weird scenarios.

I saw a user for example that was somewhere in Russia that GeoIP couldn't find a city for. What happened is they had something like "New York, Russia"

## Checklist

-   [ ] Tests for new code
