### PR TITLE
feat: drop IP address

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -27,7 +27,7 @@ const defaultLocationSetOnceProps = {
 }
 
 const plugin: Plugin = {
-    processEvent: async (event, { geoip, cache }) => {
+    processEvent: async (event, { geoip, cache, config }) => {
         if (!geoip) {
             throw new Error('This PostHog version does not have GeoIP capabilities! Upgrade to PostHog 1.24.0 or later')
         }
@@ -102,6 +102,10 @@ const plugin: Plugin = {
                         event.$set_once![`$initial_geoip_${key}`] = value
                         await cache.set(event.distinct_id, `${ip}|${event.timestamp || ''}`, ONE_DAY)
                     }
+                }
+
+                if (config.dropIPAddress) {
+                    event.ip = null
                 }
             }
         }

--- a/index.ts
+++ b/index.ts
@@ -106,6 +106,7 @@ const plugin: Plugin = {
 
                 if (config.dropIPAddress) {
                     event.ip = null
+                    event.properties.ip = null
                 }
             }
         }

--- a/plugin.json
+++ b/plugin.json
@@ -4,5 +4,14 @@
     "description": "Enrich PostHog events and persons with IP location data",
     "main": "index.ts",
     "posthogVersion": ">=1.24.0",
-    "stateless": true
+    "stateless": true,
+    "config": [
+        {
+            "key": "dropIPAddress",
+            "hint": "Drops IP address (which is PII) after doing the Geo lookup. Great for preserving end user's privacy.",
+            "name": "Drop IP Address",
+            "type": "boolean",
+            "required": true
+        }
+    ]
 }


### PR DESCRIPTION
## Changes
- Introduces a setting to Drop IP address. If enabled, the IP address information is completely discarded after doing the Geo-IP lookup.

Was requested in the past too.

## Checklist

-   [ ] Tests for new code
