### PR TITLE
Avoid updating cache multiple times

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -100,8 +100,11 @@ const plugin: Plugin = {
                     if (setPersonProps) {
                         event.$set![`$geoip_${key}`] = value
                         event.$set_once![`$initial_geoip_${key}`] = value
-                        await cache.set(event.distinct_id, `${ip}|${event.timestamp || ''}`, ONE_DAY)
                     }
+                }
+                
+                if (setPersonProps) {
+                    await cache.set(event.distinct_id, `${ip}|${event.timestamp || ''}`, ONE_DAY)
                 }
             }
         }


### PR DESCRIPTION
GeoIP plugin was updating cache multiple times per request with the same data. This fixes that.

Take a look at the source to make sure this is correct.

Related: https://github.com/PostHog/posthog/issues/11045