### PR TITLE
fix: set person properties inside properties object

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -45,7 +45,7 @@ test('event is enriched with IP location', async () => {
 
 test('person is enriched with IP location', async () => {
     const event = await processEvent({ ...createPageview(), ip: '89.160.20.129' }, await resetMetaWithMmdb())
-    expect(event!.$set).toEqual(
+    expect(event!.properties!.$set).toEqual(
         expect.objectContaining({
             $geoip_city_name: 'Linköping',
             $geoip_country_name: 'Sweden',
@@ -59,7 +59,7 @@ test('person is enriched with IP location', async () => {
             $geoip_subdivision_1_name: 'Östergötland County',
         })
     )
-    expect(event!.$set_once).toEqual(
+    expect(event!.properties!.$set_once).toEqual(
         expect.objectContaining({
             $initial_geoip_city_name: 'Linköping',
             $initial_geoip_country_name: 'Sweden',
@@ -84,7 +84,7 @@ test('person props default to null if no values present', async () => {
         { ...createPageview(), ip: '89.160.20.129' },
         await resetMetaWithMmdb(removeCityNameFromLookupResult)
     )
-    expect(event!.$set).toEqual(
+    expect(event!.properties!.$set).toEqual(
         expect.objectContaining({
             $geoip_city_name: null, // default to null
             $geoip_country_name: 'Sweden',
@@ -98,7 +98,7 @@ test('person props default to null if no values present', async () => {
             $geoip_subdivision_1_name: 'Östergötland County',
         })
     )
-    expect(event!.$set_once).toEqual(
+    expect(event!.properties!.$set_once).toEqual(
         expect.objectContaining({
             $initial_geoip_city_name: null, // default to null
             $initial_geoip_country_name: 'Sweden',
@@ -134,7 +134,7 @@ test('$set optimization works', async () => {
 
     const testEvent1 = { ...createPageview(), ip: '89.160.20.129' }
     const processedEvent1 = await processEvent(JSON.parse(JSON.stringify(testEvent1)), meta)
-    expect(processedEvent1!.$set).toMatchObject({
+    expect(processedEvent1!.properties!.$set).toMatchObject({
         $geoip_city_name: 'Linköping',
         $geoip_country_name: 'Sweden',
         $geoip_country_code: 'SE',
@@ -149,5 +149,5 @@ test('$set optimization works', async () => {
 
     const testEvent2 = { ...createPageview(), ip: '89.160.20.129', properties: { foo: 'same IP second time' } }
     const processedEvent2 = await processEvent(JSON.parse(JSON.stringify(testEvent2)), meta)
-    expect(processedEvent2!.$set).toBeUndefined()
+    expect(processedEvent2!.properties!.$set).toBeUndefined()
 })

--- a/index.ts
+++ b/index.ts
@@ -96,10 +96,10 @@ const plugin: Plugin = {
                 }
 
                 if (setPersonProps) {
-                    if (!event.properties?.$set) {
+                    if (!event.properties.$set) {
                         event.properties.$set = {}
                     }
-                    if (!event.properties?.$set_once) {
+                    if (!event.properties.$set_once) {
                         event.properties.$set_once = {}
                     }
                     event.properties.$set = { ...defaultLocationSetProps, ...(event.$set ?? {}) }

--- a/index.ts
+++ b/index.ts
@@ -96,8 +96,14 @@ const plugin: Plugin = {
                 }
 
                 if (setPersonProps) {
-                    event.$set = { ...defaultLocationSetProps, ...(event.$set ?? {}) }
-                    event.$set_once = {
+                    if (!event.properties?.$set) {
+                        event.properties.$set = {}
+                    }
+                    if (!event.properties?.$set_once) {
+                        event.properties.$set_once = {}
+                    }
+                    event.properties.$set = { ...defaultLocationSetProps, ...(event.$set ?? {}) }
+                    event.properties.$set_once = {
                         ...defaultLocationSetOnceProps,
                         ...(event.$set_once ?? {}),
                     }
@@ -106,11 +112,11 @@ const plugin: Plugin = {
                 for (const [key, value] of Object.entries(location)) {
                     event.properties[`$geoip_${key}`] = value
                     if (setPersonProps) {
-                        event.$set![`$geoip_${key}`] = value
-                        event.$set_once![`$initial_geoip_${key}`] = value
+                        event.properties.$set![`$geoip_${key}`] = value
+                        event.properties.$set_once![`$initial_geoip_${key}`] = value
                     }
                 }
-                
+
                 if (setPersonProps) {
                     await cache.set(event.distinct_id, `${ip}|${event.timestamp || ''}`, ONE_DAY)
                 }


### PR DESCRIPTION
Setting these at the top level $set and $set_once makes it so that apps that filter out properties don't filter these out.

It's also confusing for users and us as to where properties being set are coming from. Let's standardize having these inside the properties object.