### PR TITLE
fix: Ensure we don't overwrite existing properties

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -175,6 +175,20 @@ test('$set optimization doesnt override existing properties', async () => {
         $geoip_subdivision_1_code: 'E',
         $geoip_subdivision_1_name: 'Östergötland County',
     })
+    expect(processedEvent1!.properties!.$set_once).toMatchObject({
+        c: 1,
+        d: 2,
+        $initial_geoip_city_name: 'Linköping',
+        $initial_geoip_country_name: 'Sweden',
+        $initial_geoip_country_code: 'SE',
+        $initial_geoip_continent_name: 'Europe',
+        $initial_geoip_continent_code: 'EU',
+        $initial_geoip_latitude: 58.4167,
+        $initial_geoip_longitude: 15.6167,
+        $initial_geoip_time_zone: 'Europe/Stockholm',
+        $initial_geoip_subdivision_1_code: 'E',
+        $initial_geoip_subdivision_1_name: 'Östergötland County',
+    })
 
     const testEvent2 = {
         ...createPageview(),
@@ -186,4 +200,5 @@ test('$set optimization doesnt override existing properties', async () => {
         c: 3,
         d: 4,
     })
+    expect(processedEvent2!.properties!.$set_once).toBeUndefined()
 })

--- a/index.test.ts
+++ b/index.test.ts
@@ -151,3 +151,39 @@ test('$set optimization works', async () => {
     const processedEvent2 = await processEvent(JSON.parse(JSON.stringify(testEvent2)), meta)
     expect(processedEvent2!.properties!.$set).toBeUndefined()
 })
+
+test('$set optimization doesnt override existing properties', async () => {
+    const meta = await resetMetaWithMmdb()
+
+    const testEvent1 = {
+        ...createPageview(),
+        ip: '89.160.20.129',
+        properties: { $set: { a: 1, b: 2 }, $set_once: { c: 1, d: 2 } },
+    }
+    const processedEvent1 = await processEvent(JSON.parse(JSON.stringify(testEvent1)), meta)
+    expect(processedEvent1!.properties!.$set).toMatchObject({
+        a: 1,
+        b: 2,
+        $geoip_city_name: 'Linköping',
+        $geoip_country_name: 'Sweden',
+        $geoip_country_code: 'SE',
+        $geoip_continent_name: 'Europe',
+        $geoip_continent_code: 'EU',
+        $geoip_latitude: 58.4167,
+        $geoip_longitude: 15.6167,
+        $geoip_time_zone: 'Europe/Stockholm',
+        $geoip_subdivision_1_code: 'E',
+        $geoip_subdivision_1_name: 'Östergötland County',
+    })
+
+    const testEvent2 = {
+        ...createPageview(),
+        ip: '89.160.20.129',
+        properties: { foo: 'same IP second time', $set: { c: 3, d: 4 } },
+    }
+    const processedEvent2 = await processEvent(JSON.parse(JSON.stringify(testEvent2)), meta)
+    expect(processedEvent2!.properties!.$set).toMatchObject({
+        c: 3,
+        d: 4,
+    })
+})

--- a/index.test.ts
+++ b/index.test.ts
@@ -84,34 +84,36 @@ test('person props default to null if no values present', async () => {
         { ...createPageview(), ip: '89.160.20.129' },
         await resetMetaWithMmdb(removeCityNameFromLookupResult)
     )
-    expect(event!.properties!.$set).toEqual(
-        expect.objectContaining({
-            $geoip_city_name: null, // default to null
-            $geoip_country_name: 'Sweden',
-            $geoip_country_code: 'SE',
-            $geoip_continent_name: 'Europe',
-            $geoip_continent_code: 'EU',
-            $geoip_latitude: 58.4167,
-            $geoip_longitude: 15.6167,
-            $geoip_time_zone: 'Europe/Stockholm',
-            $geoip_subdivision_1_code: 'E',
-            $geoip_subdivision_1_name: 'Östergötland County',
-        })
-    )
-    expect(event!.properties!.$set_once).toEqual(
-        expect.objectContaining({
-            $initial_geoip_city_name: null, // default to null
-            $initial_geoip_country_name: 'Sweden',
-            $initial_geoip_country_code: 'SE',
-            $initial_geoip_continent_name: 'Europe',
-            $initial_geoip_continent_code: 'EU',
-            $initial_geoip_latitude: 58.4167,
-            $initial_geoip_longitude: 15.6167,
-            $initial_geoip_time_zone: 'Europe/Stockholm',
-            $initial_geoip_subdivision_1_code: 'E',
-            $initial_geoip_subdivision_1_name: 'Östergötland County',
-        })
-    )
+    expect(event!.properties!.$set).toEqual({
+        $geoip_city_name: null, // default to null
+        $geoip_country_name: 'Sweden',
+        $geoip_country_code: 'SE',
+        $geoip_continent_name: 'Europe',
+        $geoip_continent_code: 'EU',
+        $geoip_latitude: 58.4167,
+        $geoip_longitude: 15.6167,
+        $geoip_time_zone: 'Europe/Stockholm',
+        $geoip_subdivision_1_code: 'E',
+        $geoip_subdivision_1_name: 'Östergötland County',
+        $geoip_subdivision_2_code: null,
+        $geoip_subdivision_2_name: null,
+        $geoip_postal_code: null,
+    })
+    expect(event!.properties!.$set_once).toEqual({
+        $initial_geoip_city_name: null, // default to null
+        $initial_geoip_country_name: 'Sweden',
+        $initial_geoip_country_code: 'SE',
+        $initial_geoip_continent_name: 'Europe',
+        $initial_geoip_continent_code: 'EU',
+        $initial_geoip_latitude: 58.4167,
+        $initial_geoip_longitude: 15.6167,
+        $initial_geoip_time_zone: 'Europe/Stockholm',
+        $initial_geoip_subdivision_1_code: 'E',
+        $initial_geoip_subdivision_1_name: 'Östergötland County',
+        $initial_geoip_subdivision_2_code: null,
+        $initial_geoip_subdivision_2_name: null,
+        $initial_geoip_postal_code: null,
+    })
 })
 
 test('error is thrown if meta.geoip is not provided', async () => {
@@ -134,7 +136,7 @@ test('$set optimization works', async () => {
 
     const testEvent1 = { ...createPageview(), ip: '89.160.20.129' }
     const processedEvent1 = await processEvent(JSON.parse(JSON.stringify(testEvent1)), meta)
-    expect(processedEvent1!.properties!.$set).toMatchObject({
+    expect(processedEvent1!.properties!.$set).toEqual({
         $geoip_city_name: 'Linköping',
         $geoip_country_name: 'Sweden',
         $geoip_country_code: 'SE',
@@ -145,6 +147,9 @@ test('$set optimization works', async () => {
         $geoip_time_zone: 'Europe/Stockholm',
         $geoip_subdivision_1_code: 'E',
         $geoip_subdivision_1_name: 'Östergötland County',
+        $geoip_postal_code: null,
+        $geoip_subdivision_2_code: null,
+        $geoip_subdivision_2_name: null,
     })
 
     const testEvent2 = { ...createPageview(), ip: '89.160.20.129', properties: { foo: 'same IP second time' } }
@@ -161,7 +166,7 @@ test('$set optimization doesnt override existing properties', async () => {
         properties: { $set: { a: 1, b: 2 }, $set_once: { c: 1, d: 2 } },
     }
     const processedEvent1 = await processEvent(JSON.parse(JSON.stringify(testEvent1)), meta)
-    expect(processedEvent1!.properties!.$set).toMatchObject({
+    expect(processedEvent1!.properties!.$set).toEqual({
         a: 1,
         b: 2,
         $geoip_city_name: 'Linköping',
@@ -174,8 +179,11 @@ test('$set optimization doesnt override existing properties', async () => {
         $geoip_time_zone: 'Europe/Stockholm',
         $geoip_subdivision_1_code: 'E',
         $geoip_subdivision_1_name: 'Östergötland County',
+        $geoip_postal_code: null,
+        $geoip_subdivision_2_code: null,
+        $geoip_subdivision_2_name: null,
     })
-    expect(processedEvent1!.properties!.$set_once).toMatchObject({
+    expect(processedEvent1!.properties!.$set_once).toEqual({
         c: 1,
         d: 2,
         $initial_geoip_city_name: 'Linköping',
@@ -188,6 +196,9 @@ test('$set optimization doesnt override existing properties', async () => {
         $initial_geoip_time_zone: 'Europe/Stockholm',
         $initial_geoip_subdivision_1_code: 'E',
         $initial_geoip_subdivision_1_name: 'Östergötland County',
+        $initial_geoip_postal_code: null,
+        $initial_geoip_subdivision_2_code: null,
+        $initial_geoip_subdivision_2_name: null,
     })
 
     const testEvent2 = {
@@ -196,7 +207,7 @@ test('$set optimization doesnt override existing properties', async () => {
         properties: { foo: 'same IP second time', $set: { c: 3, d: 4 } },
     }
     const processedEvent2 = await processEvent(JSON.parse(JSON.stringify(testEvent2)), meta)
-    expect(processedEvent2!.properties!.$set).toMatchObject({
+    expect(processedEvent2!.properties!.$set).toEqual({
         c: 3,
         d: 4,
     })

--- a/index.ts
+++ b/index.ts
@@ -102,10 +102,10 @@ const plugin: Plugin = {
                     if (!event.properties.$set_once) {
                         event.properties.$set_once = {}
                     }
-                    event.properties.$set = { ...defaultLocationSetProps, ...(event.$set ?? {}) }
+                    event.properties.$set = { ...defaultLocationSetProps, ...(event.properties.$set ?? {}) }
                     event.properties.$set_once = {
                         ...defaultLocationSetOnceProps,
-                        ...(event.$set_once ?? {}),
+                        ...(event.properties.$set_once ?? {}),
                     }
                 }
 


### PR DESCRIPTION
## Changes

https://github.com/PostHog/posthog-plugin-geoip/pull/20 seems to have introduced a nasty bug where properties sent by a user were overridden by geoIP properties 😬 .

Brought to my attention by a customer: https://posthog.slack.com/archives/C0386ASS3TN/p1676027344218899

...

## Checklist

-   [ ] Tests for new code
