### PR TITLE
chore: Add confidence to geolocation data

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -30,12 +30,14 @@ test('event is enriched with IP location', async () => {
     expect(event!.properties).toEqual(
         expect.objectContaining({
             $geoip_city_name: 'Linköping',
+            $geoip_city_confidence: null,
             $geoip_country_name: 'Sweden',
             $geoip_country_code: 'SE',
             $geoip_continent_name: 'Europe',
             $geoip_continent_code: 'EU',
             $geoip_latitude: 58.4167,
             $geoip_longitude: 15.6167,
+            $geoip_accuracy_radius: 76,
             $geoip_time_zone: 'Europe/Stockholm',
             $geoip_subdivision_1_code: 'E',
             $geoip_subdivision_1_name: 'Östergötland County',
@@ -86,12 +88,14 @@ test('person props default to null if no values present', async () => {
     )
     expect(event!.properties!.$set).toEqual({
         $geoip_city_name: null, // default to null
+        $geoip_city_confidence: null,
         $geoip_country_name: 'Sweden',
         $geoip_country_code: 'SE',
         $geoip_continent_name: 'Europe',
         $geoip_continent_code: 'EU',
         $geoip_latitude: 58.4167,
         $geoip_longitude: 15.6167,
+        $geoip_accuracy_radius: 76,
         $geoip_time_zone: 'Europe/Stockholm',
         $geoip_subdivision_1_code: 'E',
         $geoip_subdivision_1_name: 'Östergötland County',

--- a/index.test.ts
+++ b/index.test.ts
@@ -105,12 +105,14 @@ test('person props default to null if no values present', async () => {
     })
     expect(event!.properties!.$set_once).toEqual({
         $initial_geoip_city_name: null, // default to null
+        $initial_geoip_city_confidence: null,
         $initial_geoip_country_name: 'Sweden',
         $initial_geoip_country_code: 'SE',
         $initial_geoip_continent_name: 'Europe',
         $initial_geoip_continent_code: 'EU',
         $initial_geoip_latitude: 58.4167,
         $initial_geoip_longitude: 15.6167,
+        $initial_geoip_accuracy_radius: 76,
         $initial_geoip_time_zone: 'Europe/Stockholm',
         $initial_geoip_subdivision_1_code: 'E',
         $initial_geoip_subdivision_1_name: 'Östergötland County',

--- a/index.ts
+++ b/index.ts
@@ -50,6 +50,7 @@ const plugin: Plugin = {
                 const location: Record<string, any> = {}
                 if (response.city) {
                     location['city_name'] = response.city.names?.en
+                    location['confidence'] = response.city.confidence
                 }
                 if (response.country) {
                     location['country_name'] = response.country.names?.en

--- a/index.ts
+++ b/index.ts
@@ -54,7 +54,7 @@ const plugin: Plugin = {
                 const location: Record<string, any> = {}
                 if (response.city) {
                     location['city_name'] = response.city.names?.en
-                    location['city_confidence'] = response.city.confidence
+                    location['city_confidence'] = response.city.confidence ?? null
                 }
                 if (response.country) {
                     location['country_name'] = response.country.names?.en

--- a/index.ts
+++ b/index.ts
@@ -4,6 +4,7 @@ const ONE_DAY = 60 * 60 * 24 // 24h in seconds
 
 const defaultLocationSetProps = {
     $geoip_city_name: null,
+    $geoip_city_confidence: null,
     $geoip_subdivision_2_name: null,
     $geoip_subdivision_2_code: null,
     $geoip_subdivision_1_name: null,
@@ -15,11 +16,13 @@ const defaultLocationSetProps = {
     $geoip_postal_code: null,
     $geoip_latitude: null,
     $geoip_longitude: null,
+    $geoip_accuracy_radius: null,
     $geoip_time_zone: null,
 }
 
 const defaultLocationSetOnceProps = {
     $initial_geoip_city_name: null,
+    $initial_geoip_city_confidence: null,
     $initial_geoip_subdivision_2_name: null,
     $initial_geoip_subdivision_2_code: null,
     $initial_geoip_subdivision_1_name: null,
@@ -31,6 +34,7 @@ const defaultLocationSetOnceProps = {
     $initial_geoip_postal_code: null,
     $initial_geoip_latitude: null,
     $initial_geoip_longitude: null,
+    $initial_geoip_accuracy_radius: null,
     $initial_geoip_time_zone: null,
 }
 
@@ -50,7 +54,7 @@ const plugin: Plugin = {
                 const location: Record<string, any> = {}
                 if (response.city) {
                     location['city_name'] = response.city.names?.en
-                    location['confidence'] = response.city.confidence
+                    location['city_confidence'] = response.city.confidence
                 }
                 if (response.country) {
                     location['country_name'] = response.country.names?.en
@@ -66,6 +70,7 @@ const plugin: Plugin = {
                 if (response.location) {
                     location['latitude'] = response.location?.latitude
                     location['longitude'] = response.location?.longitude
+                    location['accuracy_radius'] = response.location?.accuracyRadius
                     location['time_zone'] = response.location?.timeZone
                 }
                 if (response.subdivisions) {


### PR DESCRIPTION
Geolocation data can vary in confidence, it is useful to know both the location (the city) and the radius